### PR TITLE
Improve slug handling in API and fix side page fetch

### DIFF
--- a/src/app/api/sideInhalt/route.ts
+++ b/src/app/api/sideInhalt/route.ts
@@ -4,12 +4,28 @@ import path from "path"
 //@ts-ignore
 export async function POST(req){
     const { slug } = await req.json()
-    //console.log(slug)
-    const pfad = path.join(process.cwd(),`/src/app/realDelo/ErsteSeite/${slug}.md`)
-    console.log(pfad)
-    const inhalt = fs.readFileSync(pfad,"utf-8")
-   //console.log(inhalt)
+
+    const baseDir = path.join(process.cwd(), "src/app/realDelo/ErsteSeite")
+    const filePath = path.join(baseDir, `${slug}.md`)
+
+    let targetPath = filePath
+
+    if (!fs.existsSync(filePath)) {
+        const folderPath = path.join(baseDir, slug)
+        if (fs.existsSync(folderPath) && fs.lstatSync(folderPath).isDirectory()) {
+            targetPath = path.join(folderPath, "Readme.md")
+        } else {
+            return NextResponse.json({ message: `Slug '${slug}' not found` }, { status: 404 })
+        }
+    }
+
+    if (!fs.existsSync(targetPath)) {
+        return NextResponse.json({ message: `File for slug '${slug}' not found` }, { status: 404 })
+    }
+
+    const inhalt = fs.readFileSync(targetPath, "utf-8")
+
     return NextResponse.json({
-        content:inhalt
+        content: inhalt
     })
 }

--- a/src/app/sidePages/[slug]/page.tsx
+++ b/src/app/sidePages/[slug]/page.tsx
@@ -8,27 +8,30 @@ export default function sidePages(){
     const { slug } = useParams()
     useEffect(()=>{
         async function posten(){
-            const rohDaten = fetch("/api/sideInhalt/",{
+            const rohDaten = await fetch("/api/sideInhalt/",{
                 method:"POST",
                 headers: {
                     "Content-Type": "application/json",
-                  },
+                },
                 body: JSON.stringify({
-                    slug:slug
+                    slug: slug
                 })
             })
+
             //@ts-ignore
             if(!rohDaten.ok){
                 console.error("Fehler!", rohDaten)
                 //@ts-ignore
                 setInhalt(`Error:${rohDaten.status}`)
+                return
             }
-            const realInhalt = (await rohDaten).json()
+
+            const realInhalt = await rohDaten.json()
             //@ts-ignore
             setInhalt(realInhalt.content)
         }
         posten()
-    },[slug,inhalt])
+    },[slug])
     return(
         <>
             <div>


### PR DESCRIPTION
## Summary
- add file/folder detection to the `sideInhalt` API
- return 404 when slug is invalid or missing files
- await fetch in `[slug]` page and remove `inhalt` from deps

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845fcfbd674832bb2173c3ea8369aa0