### PR TITLE
Fix Next.js setup issues

### DIFF
--- a/src/app/api/Fileinhalt/route.ts
+++ b/src/app/api/Fileinhalt/route.ts
@@ -4,7 +4,7 @@ import { NextResponse } from "next/server"
 import path from "path"
 
 export async function GET(){
-    const pfad = path.join(process.cwd(),'/src/app/realDelo/ErsteSeite/Readme.md')
+    const pfad = path.join(process.cwd(), 'src/app/realDelo/ErsteSeite/Readme.md')
     const rohInhalt = fs.readFileSync(pfad,"utf-8")
     return NextResponse.json({
         props:{ fileInhalt : rohInhalt }

--- a/src/app/webcompos/Body.tsx
+++ b/src/app/webcompos/Body.tsx
@@ -1,6 +1,3 @@
-
-
-
 "use client"
 import { useEffect, useState } from "react"
 import Header from "./Header"


### PR DESCRIPTION
## Summary
- fix markdown file path in Fileinhalt API route
- move "use client" to top of Body component

## Testing
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_684600355c20832b84490ef7414b215d