### PR TITLE
Handle images in side pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",
-    "tailwind-merge": "^3.3.0"
+    "tailwind-merge": "^3.3.0",
+    "mime-types": "^3.0.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/src/app/api/attachment/route.ts
+++ b/src/app/api/attachment/route.ts
@@ -1,0 +1,25 @@
+import fs from "fs"
+import path from "path"
+import { NextResponse, NextRequest } from "next/server"
+import mime from "mime-types"
+
+export async function GET(req: NextRequest){
+    const { searchParams } = new URL(req.url)
+    const relPath = searchParams.get('path')
+    if(!relPath){
+        return NextResponse.json({error: 'No path provided'}, {status: 400})
+    }
+    const baseDir = path.join(process.cwd(), 'src/app/realDelo/ErsteSeite')
+    const filePath = path.join(baseDir, relPath)
+    if(!filePath.startsWith(baseDir)){
+        return NextResponse.json({error: 'Invalid path'}, {status: 400})
+    }
+    if(!fs.existsSync(filePath)){
+        return NextResponse.json({error: 'File not found'}, {status: 404})
+    }
+    const data = fs.readFileSync(filePath)
+    const type = mime.lookup(filePath) || 'application/octet-stream'
+    return new NextResponse(data, {
+        headers: { 'Content-Type': type }
+    })
+}

--- a/src/app/sidePages/[slug]/page.tsx
+++ b/src/app/sidePages/[slug]/page.tsx
@@ -2,9 +2,10 @@
 import Link from "next/link"
 import { useParams } from "next/navigation"
 import { useEffect, useState } from "react"
+import ReactMarkdown from "react-markdown"
 
 export default function sidePages(){
-    const [inhalt,setInhalt] = useState()
+    const [inhalt,setInhalt] = useState<string>()
     const { slug } = useParams()
     useEffect(()=>{
         async function posten(){
@@ -34,8 +35,17 @@ export default function sidePages(){
     },[slug])
     return(
         <>
-            <div>
-                {inhalt}
+            <div className=" max-w-150 lg:max-w-200 justify-self-center text-2xl">
+                {inhalt && (
+                    <ReactMarkdown
+                        components={{
+                            h2:({node,...props})=> <p className=" text-3xl text-justify my-5 font-bold" {...props}/>,
+                            p:({node,...props})=> <p className=" text-2xl text-justify" {...props}/>,
+                            img:({node,...props})=> <img className="my-4" {...props}/>
+                        }}>
+                        {inhalt}
+                    </ReactMarkdown>
+                )}
                 <Link href={"/"}>zurück</Link>
             </div>
         </>


### PR DESCRIPTION
## Summary
- add `mime-types` dependency
- process markdown images in `sideInhalt` API
- add new API route to serve attachments
- format side pages using `ReactMarkdown`

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6846a72b9f64832b96ab9bf6da45e105