### PR TITLE
Integrate article previews and full pages

### DIFF
--- a/src/app/api/sideInhalt/route.ts
+++ b/src/app/api/sideInhalt/route.ts
@@ -1,7 +1,7 @@
 import fs from "fs"
 import { NextResponse } from "next/server"
 import path from "path"
-//@ts-ignore
+//@ts-expect-error req type is from next 13 fetch
 export async function POST(req){
     const { slug } = await req.json()
 

--- a/src/app/sidePages/[slug]/archive/[index]/page.tsx
+++ b/src/app/sidePages/[slug]/archive/[index]/page.tsx
@@ -1,0 +1,39 @@
+"use client"
+import Link from "next/link"
+import { useParams } from "next/navigation"
+import { useEffect, useState } from "react"
+import ReactMarkdown from "react-markdown"
+import { fileMap, splitArticles } from "@/lib/sideFiles"
+
+export default function ArchiveArticle(){
+  const { slug, index } = useParams<{ slug: string; index: string }>()
+  const [article,setArticle] = useState<string>()
+
+  useEffect(()=>{
+    async function load(){
+      const file = fileMap[slug]?.archive
+      if(!file) return
+      const res = await fetch("/api/sideInhalt/",{
+        method:"POST",
+        headers:{"Content-Type":"application/json"},
+        body: JSON.stringify({slug:`${slug}/${file.replace(/\.md$/,'')}`})
+      })
+      if(res.ok){
+        const j = await res.json()
+        const arts = splitArticles(j.content)
+        const idx = parseInt(index,10)
+        if(!isNaN(idx) && idx < arts.length){
+          setArticle(arts[idx])
+        }
+      }
+    }
+    load()
+  },[slug,index])
+
+  return (
+    <div className="max-w-150 lg:max-w-200 mx-auto">
+      {article && <ReactMarkdown>{article}</ReactMarkdown>}
+      <Link href={`/sidePages/${slug}`} className="underline mt-4 inline-block">zurück</Link>
+    </div>
+  )
+}

--- a/src/app/sidePages/[slug]/news/[index]/page.tsx
+++ b/src/app/sidePages/[slug]/news/[index]/page.tsx
@@ -1,0 +1,39 @@
+"use client"
+import Link from "next/link"
+import { useParams } from "next/navigation"
+import { useEffect, useState } from "react"
+import ReactMarkdown from "react-markdown"
+import { fileMap, splitArticles } from "@/lib/sideFiles"
+
+export default function NewsArticle(){
+  const { slug, index } = useParams<{ slug: string; index: string }>()
+  const [article,setArticle] = useState<string>()
+
+  useEffect(()=>{
+    async function load(){
+      const file = fileMap[slug]?.news
+      if(!file) return
+      const res = await fetch("/api/sideInhalt/",{
+        method:"POST",
+        headers:{"Content-Type":"application/json"},
+        body: JSON.stringify({slug:`${slug}/${file.replace(/\.md$/,'')}`})
+      })
+      if(res.ok){
+        const j = await res.json()
+        const arts = splitArticles(j.content)
+        const idx = parseInt(index,10)
+        if(!isNaN(idx) && idx < arts.length){
+          setArticle(arts[idx])
+        }
+      }
+    }
+    load()
+  },[slug,index])
+
+  return (
+    <div className="max-w-150 lg:max-w-200 mx-auto">
+      {article && <ReactMarkdown>{article}</ReactMarkdown>}
+      <Link href={`/sidePages/${slug}`} className="underline mt-4 inline-block">zurück</Link>
+    </div>
+  )
+}

--- a/src/app/sidePages/[slug]/page.tsx
+++ b/src/app/sidePages/[slug]/page.tsx
@@ -2,41 +2,98 @@
 import Link from "next/link"
 import { useParams } from "next/navigation"
 import { useEffect, useState } from "react"
+import ReactMarkdown from "react-markdown"
+import { articleIntro, fileMap, splitArticles } from "@/lib/sideFiles"
 
-export default function sidePages(){
-    const [inhalt,setInhalt] = useState()
-    const { slug } = useParams()
+export default function SidePages(){
+    const [inhalt,setInhalt] = useState<string>()
+    const [news,setNews] = useState<string[]>([])
+    const [archive,setArchive] = useState<string[]>([])
+    const { slug } = useParams<{ slug: string }>()
+
     useEffect(()=>{
-        async function posten(){
-            const rohDaten = await fetch("/api/sideInhalt/",{
+        async function laden(){
+            const baseRes = await fetch("/api/sideInhalt/",{
                 method:"POST",
-                headers: {
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    slug: slug
-                })
+                headers:{"Content-Type":"application/json"},
+                body: JSON.stringify({slug})
             })
-
-            //@ts-ignore
-            if(!rohDaten.ok){
-                console.error("Fehler!", rohDaten)
-                //@ts-ignore
-                setInhalt(`Error:${rohDaten.status}`)
-                return
+            if(baseRes.ok){
+                const json = await baseRes.json()
+                setInhalt(json.content)
+            } else {
+                setInhalt(`Error:${baseRes.status}`)
             }
 
-            const realInhalt = await rohDaten.json()
-            //@ts-ignore
-            setInhalt(realInhalt.content)
+            const files = fileMap[slug as string]
+            if(files?.news){
+                const res = await fetch("/api/sideInhalt/",{
+                    method:"POST",
+                    headers:{"Content-Type":"application/json"},
+                    body: JSON.stringify({slug:`${slug}/${files.news.replace(/\.md$/,"")}`})
+                })
+                if(res.ok){
+                    const j = await res.json()
+                    setNews(splitArticles(j.content))
+                }
+            }
+            if(files?.archive){
+                const res = await fetch("/api/sideInhalt/",{
+                    method:"POST",
+                    headers:{"Content-Type":"application/json"},
+                    body: JSON.stringify({slug:`${slug}/${files.archive.replace(/\.md$/,"")}`})
+                })
+                if(res.ok){
+                    const j = await res.json()
+                    setArchive(splitArticles(j.content))
+                }
+            }
         }
-        posten()
+        laden()
     },[slug])
+
     return(
         <>
-            <div>
-                {inhalt}
-                <Link href={"/"}>zurück</Link>
+            <div className="max-w-150 lg:max-w-200 mx-auto">
+                {inhalt && (
+                    <ReactMarkdown className="mb-10">{inhalt}</ReactMarkdown>
+                )}
+
+                {news.length > 0 && (
+                    <>
+                        <h2 className="text-3xl font-bold mb-4">Aktuelles</h2>
+                        {news.map((art,i)=>{
+                            const { heading, snippet, image } = articleIntro(art)
+                            return (
+                                <div key={i} className="border rounded-md shadow p-4 mb-4">
+                                    <ReactMarkdown>{`## ${heading}`}</ReactMarkdown>
+                                    {image && <img src={image} className="my-2 max-h-60" alt="" />}
+                                    <p>{snippet}...</p>
+                                    <Link href={`/sidePages/${slug}/news/${i}`} className="mt-2 inline-block underline">mehr</Link>
+                                </div>
+                            )
+                        })}
+                    </>
+                )}
+
+                {archive.length > 0 && (
+                    <>
+                        <h2 className="text-3xl font-bold my-4">Archiv</h2>
+                        {archive.map((art,i)=>{
+                            const { heading, snippet, image } = articleIntro(art)
+                            return (
+                                <div key={i} className="border rounded-md shadow p-4 mb-4">
+                                    <ReactMarkdown>{`## ${heading}`}</ReactMarkdown>
+                                    {image && <img src={image} className="my-2 max-h-60" alt="" />}
+                                    <p>{snippet}...</p>
+                                    <Link href={`/sidePages/${slug}/archive/${i}`} className="mt-2 inline-block underline">mehr</Link>
+                                </div>
+                            )
+                        })}
+                    </>
+                )}
+
+                <Link href="/">zurück</Link>
             </div>
         </>
     )

--- a/src/app/webcompos/Body.tsx
+++ b/src/app/webcompos/Body.tsx
@@ -19,8 +19,8 @@ export default function Body(){
             <div className=" max-w-150 lg:max-w-200 justify-self-center text-2xl">
                 <ReactMarkdown
                     components={{
-                        h2:({node,...props})=><p className=" text-3xl text-justify my-5 font-bold"{...props}/>,
-                        p:({node,...props})=><p className=" text-2xl text-justify"{...props}/>,  
+                        h2: (props) => <p className=" text-3xl text-justify my-5 font-bold" {...props} />,
+                        p: (props) => <p className=" text-2xl text-justify" {...props} />,
                     }}>
                     {fileInhalt}
                 </ReactMarkdown>

--- a/src/lib/sideFiles.ts
+++ b/src/lib/sideFiles.ts
@@ -1,0 +1,25 @@
+export interface FileInfo {
+  news?: string;
+  archive?: string;
+}
+
+export const fileMap: Record<string, FileInfo> = {
+  MUUN: { news: "Aktuelles zu MINT und UNESCO.md", archive: "Archiv zu MINT und UNESCO.md" },
+  mintEvents: { news: "Aktuelles zu Events.md", archive: "Archiv zu Events.md" },
+  mintSpezial: { news: "Aktuelles zu Spezial.md", archive: "Archiv zu Spezial.md" },
+};
+
+export function splitArticles(text: string): string[] {
+  return text.split(/\n(?=##\s)/g).filter((p) => p.trim() !== "");
+}
+
+export function articleIntro(article: string) {
+  const headingMatch = article.match(/^##\s*(.+)/);
+  const heading = headingMatch ? headingMatch[1].trim() : "";
+  let rest = article.replace(/^##\s*.+\n?/, "");
+  const imageMatch = rest.match(/!\[[^\]]*\]\(([^)]+)\)/);
+  const image = imageMatch ? imageMatch[1] : undefined;
+  rest = rest.replace(/!\[[^\]]*\]\([^)]*\)/g, "");
+  const snippet = rest.trim().replace(/\n+/g, " ").slice(0, 40);
+  return { heading, snippet, image };
+}


### PR DESCRIPTION
## Summary
- share side page file map and helper functions
- preview news and archive articles with heading, snippet and first image
- add routes for full news/archive articles
- clean up Body component and lint comment

## Testing
- `npm install`
- `npx next lint`

------
https://chatgpt.com/codex/tasks/task_e_6846ec0848a8832bb048d9d9de5d9cf1