### PR TITLE
Fix markdown list style

### DIFF
--- a/src/app/sidePages/[slug]/archive/[index]/page.tsx
+++ b/src/app/sidePages/[slug]/archive/[index]/page.tsx
@@ -32,7 +32,16 @@ export default function ArchiveArticle(){
 
   return (
     <div className="max-w-150 lg:max-w-200 mx-auto">
-      {article && <ReactMarkdown>{article}</ReactMarkdown>}
+      {article && (
+        <ReactMarkdown
+          components={{
+            ul: (props) => <ul className="list-disc pl-6 text-2xl" {...props} />,
+            li: (props) => <li className="text-2xl" {...props} />,
+          }}
+        >
+          {article}
+        </ReactMarkdown>
+      )}
       <Link href={`/sidePages/${slug}`} className="underline mt-4 inline-block">zurück</Link>
     </div>
   )

--- a/src/app/sidePages/[slug]/news/[index]/page.tsx
+++ b/src/app/sidePages/[slug]/news/[index]/page.tsx
@@ -32,7 +32,16 @@ export default function NewsArticle(){
 
   return (
     <div className="max-w-150 lg:max-w-200 mx-auto">
-      {article && <ReactMarkdown>{article}</ReactMarkdown>}
+      {article && (
+        <ReactMarkdown
+          components={{
+            ul: (props) => <ul className="list-disc pl-6 text-2xl" {...props} />,
+            li: (props) => <li className="text-2xl" {...props} />,
+          }}
+        >
+          {article}
+        </ReactMarkdown>
+      )}
       <Link href={`/sidePages/${slug}`} className="underline mt-4 inline-block">zurück</Link>
     </div>
   )

--- a/src/app/sidePages/[slug]/page.tsx
+++ b/src/app/sidePages/[slug]/page.tsx
@@ -60,6 +60,8 @@ export default function SidePages(){
                         h2: (props) => <p className="text-3xl text-justify my-5 font-bold" {...props}/>,
                         p: (props) => <p className="text-2xl text-justify" {...props}/>,
                         img: (props) => <img className="my-4" alt="" {...props}/>
+                        ul: (props) => <ul className="list-disc pl-6 text-2xl" {...props}/>,
+                        li: (props) => <li className="text-2xl" {...props}/>,
                     }}>
                     {inhalt}
                 </ReactMarkdown>

--- a/src/app/webcompos/Body.tsx
+++ b/src/app/webcompos/Body.tsx
@@ -19,6 +19,8 @@ export default function Body(){
                     components={{
                         h2: (props) => <p className=" text-3xl text-justify my-5 font-bold" {...props} />,
                         p: (props) => <p className=" text-2xl text-justify" {...props} />,
+                        ul: (props) => <ul className="list-disc pl-6 text-2xl" {...props} />, 
+                        li: (props) => <li className="text-2xl" {...props} />,
                     }}>
                     {fileInhalt}
                 </ReactMarkdown>


### PR DESCRIPTION
## Summary
- show bullet points in markdown lists and use consistent font sizing

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684711d19264832b816c49d5e241a119