### PR TITLE
Fix markdown h3 styling

### DIFF
--- a/src/app/sidePages/[slug]/archive/[index]/page.tsx
+++ b/src/app/sidePages/[slug]/archive/[index]/page.tsx
@@ -35,6 +35,9 @@ export default function ArchiveArticle(){
       {article && (
         <ReactMarkdown
           components={{
+            h3: (props) => (
+              <p className="text-[1.75rem] text-justify my-3 font-semibold" {...props} />
+            ),
             ul: (props) => <ul className="list-disc pl-6 text-2xl" {...props} />,
             li: (props) => <li className="text-2xl" {...props} />,
           }}

--- a/src/app/sidePages/[slug]/news/[index]/page.tsx
+++ b/src/app/sidePages/[slug]/news/[index]/page.tsx
@@ -35,6 +35,9 @@ export default function NewsArticle(){
       {article && (
         <ReactMarkdown
           components={{
+            h3: (props) => (
+              <p className="text-[1.75rem] text-justify my-3 font-semibold" {...props} />
+            ),
             ul: (props) => <ul className="list-disc pl-6 text-2xl" {...props} />,
             li: (props) => <li className="text-2xl" {...props} />,
           }}

--- a/src/app/sidePages/[slug]/page.tsx
+++ b/src/app/sidePages/[slug]/page.tsx
@@ -57,11 +57,12 @@ export default function SidePages(){
             {inhalt && (
                 <ReactMarkdown
                     components={{
-                        h2: (props) => <p className="text-3xl text-justify my-5 font-bold" {...props}/>,
-                        p: (props) => <p className="text-2xl text-justify" {...props}/>,
-                        img: (props) => <img className="my-4" alt="" {...props}/>
-                        ul: (props) => <ul className="list-disc pl-6 text-2xl" {...props}/>,
-                        li: (props) => <li className="text-2xl" {...props}/>,
+                        h2: (props) => (<p className="text-3xl text-justify my-5 font-bold" {...props} />),
+                        h3: (props) => (<p className="text-[1.75rem] text-justify my-3 font-semibold" {...props} />),
+                        p: (props) => (<p className="text-2xl text-justify" {...props} />),
+                        img: (props) => (<img className="my-4" alt="" {...props} />),
+                        ul: (props) => (<ul className="list-disc pl-6 text-2xl" {...props} />),
+                        li: (props) => (<li className="text-2xl" {...props} />),
                     }}>
                     {inhalt}
                 </ReactMarkdown>

--- a/src/app/webcompos/Body.tsx
+++ b/src/app/webcompos/Body.tsx
@@ -17,10 +17,21 @@ export default function Body(){
             <div className=" max-w-150 lg:max-w-200 justify-self-center text-2xl">
                 <ReactMarkdown
                     components={{
-                        h2: (props) => <p className=" text-3xl text-justify my-5 font-bold" {...props} />,
-                        p: (props) => <p className=" text-2xl text-justify" {...props} />,
-                        ul: (props) => <ul className="list-disc pl-6 text-2xl" {...props} />, 
-                        li: (props) => <li className="text-2xl" {...props} />,
+                        h2: (props) => (
+                            <p className=" text-3xl text-justify my-5 font-bold" {...props} />
+                        ),
+                        h3: (props) => (
+                            <p className=" text-[1.75rem] text-justify my-3 font-semibold" {...props} />
+                        ),
+                        p: (props) => (
+                            <p className=" text-2xl text-justify" {...props} />
+                        ),
+                        ul: (props) => (
+                            <ul className="list-disc pl-6 text-2xl" {...props} />
+                        ),
+                        li: (props) => (
+                            <li className="text-2xl" {...props} />
+                        ),
                     }}>
                     {fileInhalt}
                 </ReactMarkdown>


### PR DESCRIPTION
## Summary
- ensure h3 headings are styled larger than body text
- fix corrupted `sidePages/[slug]/page.tsx`
- add custom h3 handling for side page articles and body component

## Testing
- `npx next lint`

------
https://chatgpt.com/codex/tasks/task_e_6847134fc414832b93391a4f616e8f81